### PR TITLE
Header infiniband/arch.h has been deprecated, use glibc's <endian.h>

### DIFF
--- a/include/mooshika.h
+++ b/include/mooshika.h
@@ -32,7 +32,6 @@
 #ifndef _MOOSHIKA_H
 #define _MOOSHIKA_H
 
-#include <infiniband/arch.h>
 #include <rdma/rdma_cma.h>
 
 #define MOOSHIKA_API_VERSION 5

--- a/src/trans_rdma.c
+++ b/src/trans_rdma.c
@@ -38,6 +38,7 @@
 #include <string.h>	//memcpy
 #include <limits.h>	//INT_MAX
 #include <inttypes.h>	//uint*_t
+#include <endian.h>     //be64toh
 #include <errno.h>	//ENOMEM
 #include <sys/socket.h> //sockaddr
 #include <sys/un.h>     //sockaddr_un
@@ -53,7 +54,6 @@
 #define EPOLL_MAX_EVENTS 16
 #define NUM_WQ_PER_POLL 16
 
-#include <infiniband/arch.h>
 #include <rdma/rdma_cma.h>
 #include <netdb.h> /* gai_strerror() */
 
@@ -341,7 +341,7 @@ msk_rloc_t *msk_make_rloc(struct ibv_mr *mr, uint64_t addr, uint32_t size) {
 void msk_print_devinfo(struct msk_trans *trans) {
 	struct ibv_device_attr device_attr;
 	ibv_query_device(trans->cm_id->verbs, &device_attr);
-	uint64_t node_guid = ntohll(device_attr.node_guid);
+	uint64_t node_guid = be64toh(device_attr.node_guid);
 	printf("guid: %04x:%04x:%04x:%04x\n",
 		(unsigned) (node_guid >> 48) & 0xffff,
 		(unsigned) (node_guid >> 32) & 0xffff,


### PR DESCRIPTION
In recent OFED versions, header infiniband/arch.h has been deprecated. glibc's endian.h should be used instead.
Use glibc's be64toh() instead of ntohll()

FYI, building mooshika with infiniband/arch.h produces the following warning and error:

  In file included from trans_rdma.c:56:0:
  /usr/include/infiniband/arch.h:37:2: error: #warning "This header is obsolete." [-Werror=cpp]
   #warning "This header is obsolete."
   ^
  trans_rdma.c: In function 'msk_print_devinfo':
  trans_rdma.c:344:2: error: 'ntohll' is deprecated (declared at /usr/include/infiniband/arch.h:44) [-Werror=deprecated-declarations]
    uint64_t node_guid = ntohll(device_attr.node_guid);